### PR TITLE
Add air quality sensor support

### DIFF
--- a/src/multiServiceAccessory.ts
+++ b/src/multiServiceAccessory.ts
@@ -25,6 +25,7 @@ import { WindowCoveringService } from './services/windowCoveringService';
 import { ThermostatService } from './services/thermostatService';
 import { StatelessProgrammableSwitchService } from './services/statelessProgrammableSwitchService';
 import { AirConditionerService } from './services/airConditionerService';
+import { AirQualityService } from './services/airQualityService';
 import { Command } from './services/smartThingsCommand';
 // type DeviceStatus = {
 //   timestamp: number;
@@ -73,6 +74,8 @@ export class MultiServiceAccessory {
     'button': StatelessProgrammableSwitchService,
     'battery': BatteryService,
     'valve': ValveService,
+    'carbonDioxideMeasurement': AirQualityService,
+    'dustSensor': AirQualityService,
   };
 
   // Maps combinations of supported capabilities to a service
@@ -115,6 +118,10 @@ export class MultiServiceAccessory {
     {
       capabilities: ['switch', 'valve'],
       service: ValveService,
+    },
+    {
+      capabilities: ['carbonDioxideMeasurement', 'dustSensor'],
+      service: AirQualityService,
     },
     {
       capabilities: ['temperatureMeasurement',

--- a/src/services/airQualityService.ts
+++ b/src/services/airQualityService.ts
@@ -1,0 +1,74 @@
+import { PlatformAccessory } from 'homebridge';
+import { IKHomeBridgeHomebridgePlatform } from '../platform';
+import { SensorService } from './sensorService';
+import { MultiServiceAccessory } from '../multiServiceAccessory';
+import { ShortEvent } from '../webhook/subscriptionHandler';
+
+export class AirQualityService extends SensorService {
+
+  constructor(platform: IKHomeBridgeHomebridgePlatform, accessory: PlatformAccessory, componentId: string, capabilities: string[],
+    multiServiceAccessory: MultiServiceAccessory,
+    name: string, deviceStatus) {
+    super(platform, accessory, componentId, capabilities, multiServiceAccessory, name, deviceStatus);
+
+    this.log.debug(`Adding AirQualityService to ${this.name}`);
+    this.initService(platform.Service.AirQualitySensor, platform.Characteristic.AirQuality, (status) => {
+      const co2 = status.carbonDioxideMeasurement.carbonDioxide.value;
+      const pm25Density = status.dustSensor.fineDustLevel.value;
+
+      if (co2 === null || co2 === undefined) {
+        this.log.warn(`${this.name} returned bad value for status`);
+        throw('Bad Value');
+      }
+
+      this.service.setCharacteristic(platform.Characteristic.CarbonDioxideLevel, co2);
+      this.service.setCharacteristic(platform.Characteristic.PM2_5Density, pm25Density);
+
+      let score = 0;
+      if (pm25Density > 55) {
+        return this.platform.Characteristic.AirQuality.POOR;
+      } else if (pm25Density > 30) {
+        score = this.platform.Characteristic.AirQuality.INFERIOR;
+      } else if (pm25Density > 15) {
+        score = this.platform.Characteristic.AirQuality.FAIR;
+      } else if (pm25Density > 7) {
+        score = this.platform.Characteristic.AirQuality.GOOD;
+      } else {
+        score = this.platform.Characteristic.AirQuality.EXCELLENT;
+      }
+
+      if (co2 > 5000) {
+        return this.platform.Characteristic.AirQuality.POOR;
+      } else if (co2 > 2500) {
+        score += this.platform.Characteristic.AirQuality.POOR;
+      } else if (co2 > 2000) {
+        score += this.platform.Characteristic.AirQuality.INFERIOR;
+      } else if (co2 > 1500) {
+        score += this.platform.Characteristic.AirQuality.FAIR;
+      } else if (co2 > 1000) {
+        score += this.platform.Characteristic.AirQuality.GOOD;
+      }
+
+      if (score > 4) {
+        return this.platform.Characteristic.AirQuality.POOR;
+      }
+      return score;
+    });
+  }
+
+  public processEvent(event: ShortEvent): void {
+    if (event.capability === 'carbonDioxideMeasurement') {
+      this.service.updateCharacteristic(this.platform.Characteristic.CarbonDioxideLevel, event.value);
+    } else if (event.capability === 'dustSensor') {
+      this.service.updateCharacteristic(this.platform.Characteristic.PM2_5Density, event.value);
+    } else {
+      return;
+    }
+
+    this.getSensorState().then(value => {
+      this.service.updateCharacteristic(this.platform.Characteristic.AirQuality, value);
+    }).catch(() => {
+      this.log.warn(`Failed to update air quality for ${this.name}`);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add AirQualityService implementation
- import AirQualityService and register with capability map
- map carbon dioxide and dust sensor capabilities
- register combo for carbonDioxideMeasurement and dustSensor

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68421736fed8832b86f7e5cbe37932d0