### PR TITLE
Use GitHub release to publish package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build and Lint
 on:
   pull_request:
     types: [opened, synchronize]
+  release:
+    types: [created]
 
 jobs:
   build:
@@ -30,8 +32,8 @@ jobs:
       - name: Create NPM package
         run: npm pack
 
-      - name: Upload NPM package
-        uses: actions/upload-artifact@v4
+      - name: Upload Release Asset
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
         with:
-          name: npm-package
-          path: '*.tgz'
+          files: '*.tgz'


### PR DESCRIPTION
## Summary
- add release workflow trigger
- upload `.tgz` to GitHub Release instead of storing as an artifact

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844c7979c80832b9c75c292c9a0c81d